### PR TITLE
Customize template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,8 @@
-# {{NAME}} Working Group
+# ROS 2 Real-Time Working Group
 
-{{
-TEMPLATE: This repository acts as a template for individual Working Groups to start from.
-All information in double curly-braces must be replaced with details for the specific Working Group.
-NOTE: check the issue and pull request templates as well, under `.github` directory.
+This document defines the scope and governance of the ROS 2 Real-Time Working Group.
 
-This is a template repository.
-When starting a new working group, [use this template](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template) to create a new repository in the WG organization.
-}}
-
-This document defines the scope and governance of the Working Group (WG).
-
-{{Mission: The {{NAME}} Working Group's mission is to...}}
-
-{{Scope: the types of topics, tools, libraries, applications, documents, etc, that this working group focuses on. }}
+The Real-Time Working Group's mission is to advocate for and work on memory management, real-time pub/sub, real-time DDS, and tools that allow tracing, profiling and optimizing.
 
 ## Subprojects
 
@@ -24,6 +13,8 @@ Its meetings and membership are largely focused on the direction, design, and wo
 
 The following subprojects are owned by the Working Group:
 
+**TODO**
+
 {{
 
 * template-project
@@ -32,6 +23,10 @@ The following subprojects are owned by the Working Group:
     * link-to-repository
 
 }}
+
+#### Related Projects
+
+**TODO**
 
 ### Standards for subprojects
 
@@ -72,19 +67,23 @@ If the repositories of the subproject are under the WG's GitHub organization, th
 
 ## Governance
 
+See the [WG section of the ROS 2 Project Governance page](https://index.ros.org/doc/ros2/Governance/#working-groups-wgs).
+
 ### Meetings
 
-* Regular WG Meeting: {{time schedule for meetings}}
-  * {{when and where will meetings be announced}}
-  * {{what artifacts will be posted after the meetings, e.g. Minutes, Recordings}}
+* Regular WG Meeting: every other Tuesday at 9 AM Pacific time, see the [ROS Events calendar](https://calendar.google.com/calendar/embed?src=agf3kajirket8khktupm9go748%40group.calendar.google.com&ctz=America%2FLos_Angeles)
+* To receive meeting invitations, join [ros-real-time-working-group-invites](https://groups.google.com/forum/#!forum/ros-real-time-working-group-invites)
+* Meetings are open to the public, and anyone is welcome to join
 
 ### Communication Channels
 
-{{How can members communicate with each other? Discourse, Discord, IRC, email list, etc.}}
+This working group uses Discourse: [wg-real-time](https://discourse.ros.org/tag/wg-real-time).
 
+<!--
 ### Backlog Management
 
 {{Is any project management software/site used to track work for this Working Group? How can new members discover the highest impact tasks they could take on? GitHub Projects, ZenHub, etc.}}
+-->
 
 ### Membership, Roles and Organization Management
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The following subprojects are owned by the Working Group:
 
 #### Related Projects
 
-**TODO**
+Related projects will be added in the future.
 
 ### Standards for subprojects
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ See the [WG section of the ROS 2 Project Governance page](https://index.ros.org/
 
 ### Meetings
 
-* Regular WG Meeting: every other Tuesday at 9 AM Pacific time, see the [ROS Events calendar](https://calendar.google.com/calendar/embed?src=agf3kajirket8khktupm9go748%40group.calendar.google.com&ctz=America%2FLos_Angeles)
+* Regular WG Meeting: every other Tuesday at 7 AM Pacific time, see the [ROS Events calendar](https://calendar.google.com/calendar/embed?src=agf3kajirket8khktupm9go748%40group.calendar.google.com&ctz=America%2FLos_Angeles)
 * To receive meeting invitations, join [ros-real-time-working-group-invites](https://groups.google.com/forum/#!forum/ros-real-time-working-group-invites)
 * Meetings are open to the public, and anyone is welcome to join
 

--- a/README.md
+++ b/README.md
@@ -11,18 +11,7 @@ Its meetings and membership are largely focused on the direction, design, and wo
 
 ### Subproject List
 
-The following subprojects are owned by the Working Group:
-
-**TODO**
-
-{{
-
-* template-project
-  * Description: Brief description of project. Remove this item and add new projects using this format.
-  * Repositories
-    * link-to-repository
-
-}}
+Subprojects will be added in the future.
 
 #### Related Projects
 


### PR DESCRIPTION
Initial customization of the template (from [here](https://github.com/ros2/tsc_working_group_governance_template)).

Notes:

* review the WG mission/scope sentence (taken from [TSC meeting minutes from 2019-05-16](https://discourse.ros.org/t/ros-2-tsc-meeting-minutes-2019-05-16/9277))
* the WG doesn't currently have any subprojects, so most of the stuff doesn't currently apply
* this project could be added as a related project: https://gitlab.com/micro-ROS/ros_tracing/ros2_tracing
* the WG hasn't yet defined "membership", but we don't really need to formally follow it (other WGs don't)

See also:

* tooling WG: https://github.com/ros-tooling/community
* security WG: https://github.com/ros-security/community
* middleware WG: https://github.com/ros2/middleware_working_group