### PR TITLE
Add CONTRIBUTING.md and governance.md documents

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# How to Contribute
+
+### Standards for subprojects
+
+Subprojects must meet the following criteria (and the WG agrees to maintain them upon adoption).
+
+* Build passes against ROS 2 master
+* The ROS 2 standard linter set is enabled and adhered to
+* If packages are part of nightly builds on the ROS build farm, there are no reported warnings or test failures
+* Quality builds are green (address sanitizer, thread sanitizer, clang thread safety analysis)
+* Test suite passes
+* Code coverage is measured, and non-decreasing level is enforced in PRs
+* Issues and pull requests receive prompt responses
+* Releases go out regularly when bugfixes or new features are introduced
+* The backlog is maintained, avoiding longstanding stale issues
+
+### Adding new subprojects
+
+To request introduction of a new subproject, add a list item to the "Subprojects" section and open a Pull Request to this repository, following the default Pull Request Template to populate the text of the PR.
+
+PR will be merged on unanimous approval from Approvers.
+
+### Subproject changes
+
+Modify the relevant list item in the "Subprojects" section and open a Pull Request to this repository, following the default Pull Request Template to populate the text of the PR.
+
+PR will be merged on unanimous approval from Approvers.
+
+### Deprecating subprojects
+
+Projects cease to be useful, or the WG can decide it is no longer in their interest to maintain.
+We do not commit to maintaining every subproject in perpetuity.
+
+To suggest removal of a subproject, remove the relevant list item in the "Subprojects" section and open a Pull Request in this repository, following instructions in the Pull Request Template to populate the text of the PR.
+
+PR will be merged on unanimous approval from Approvers.
+
+If the repositories of the subproject are under the WG's GitHub organization, they will be transferred out of the organization or deleted at this time.
+

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Real-time utilities
   - Repositories:
     - https://gitlab.com/ApexAI/apex_containers
 - realtime_tools
-  - Description: Contains a set of tools that can be used from a hard realtime thread, without breaking the realtime behavior.
+  - Description: Contains a set of tools that can be used from a hard realtime thread, without breaking the realtime behavior
   - Repositories:
     - https://github.com/ros-controls/realtime_tools/tree/foxy-devel
 
@@ -89,53 +89,12 @@ Real-time demos
   - Repositories
     - https://github.com/hsgwa/e2e_demo
 
-### Standards for subprojects
-
-Subprojects must meet the following criteria (and the WG agrees to maintain them upon adoption).
-
-* Build passes against ROS 2 master
-* The ROS 2 standard linter set is enabled and adhered to
-* If packages are part of nightly builds on the ROS build farm, there are no reported warnings or test failures
-* Quality builds are green (address sanitizer, thread sanitizer, clang thread safety analysis)
-* Test suite passes
-* Code coverage is measured, and non-decreasing level is enforced in PRs
-* Issues and pull requests receive prompt responses
-* Releases go out regularly when bugfixes or new features are introduced
-* The backlog is maintained, avoiding longstanding stale issues
-
-### Adding new subprojects
-
-To request introduction of a new subproject, add a list item to the "Subprojects" section and open a Pull Request to this repository, following the default Pull Request Template to populate the text of the PR.
-
-PR will be merged on unanimous approval from Approvers.
-
-### Subproject changes
-
-Modify the relevant list item in the "Subprojects" section and open a Pull Request to this repository, following the default Pull Request Template to populate the text of the PR.
-
-PR will be merged on unanimous approval from Approvers.
-
-### Deprecating subprojects
-
-Projects cease to be useful, or the WG can decide it is no longer in their interest to maintain.
-We do not commit to maintaining every subproject in perpetuity.
-
-To suggest removal of a subproject, remove the relevant list item in the "Subprojects" section and open a Pull Request in this repository, following instructions in the Pull Request Template to populate the text of the PR.
-
-PR will be merged on unanimous approval from Approvers.
-
-If the repositories of the subproject are under the WG's GitHub organization, they will be transferred out of the organization or deleted at this time.
-
-## Governance
-
-See the [WG section of the ROS 2 Project Governance page](https://index.ros.org/doc/ros2/Governance/#working-groups-wgs).
-
 ### Meetings
 
 * Regular WG Meeting: every other Tuesday at 7 AM Pacific time, see the [ROS Events calendar](https://calendar.google.com/calendar/embed?src=agf3kajirket8khktupm9go748%40group.calendar.google.com&ctz=America%2FLos_Angeles)
 * To receive meeting invitations, join [ros-real-time-working-group-invites](https://groups.google.com/forum/#!forum/ros-real-time-working-group-invites)
 * Meeting notes are kept under [ROS 2 Real-time Working Group Agenda](https://docs.google.com/document/d/1zBKwDUDeWvJNyCvjzYriaZQoZO2VYGWe1uxw5Xxn5cY/edit?ts=5ec9aabe#heading=h.rwvriogv081)
-* Meetings are recorded and available on Discourse: [wg-real-time](https://discourse.ros.org/tag/wg-real-time).
+* Meetings are recorded and available in [ROS 2 Real-time Working Group Agenda](https://docs.google.com/document/d/1zBKwDUDeWvJNyCvjzYriaZQoZO2VYGWe1uxw5Xxn5cY/edit?ts=5ec9aabe#heading=h.rwvriogv081).
 * Meetings are open to the public, and anyone is welcome to join
 
 ### Communication Channels
@@ -143,40 +102,11 @@ See the [WG section of the ROS 2 Project Governance page](https://index.ros.org/
 - ROS discourse tag [wg-real-time](https://discourse.ros.org/tag/wg-real-time)
 - Chat in the [Real-time WG Room on Matrix](https://matrix.to/#/#ros-realtime:matrix.org?via=matrix.org)
 
-<!--
+### Governance
 
-### Backlog Management
+See the [governance](governance.md) document for more information.
 
-{{Is any project management software/site used to track work for this Working Group? How can new members discover the highest impact tasks they could take on? GitHub Projects, ZenHub, etc.}}
--->
+### How to Contribute
 
-### Membership, Roles and Organization Management
+See the [contributing](CONTRIBUTING.md) document for more information.
 
-Working Group members may act in one or more of the following roles:
-
-* **Member**
-  * Prerequisite: Attend at least one out of the last three Working Group meetings
-  * Responsible for triaging issues
-* **Reviewer**
-  * All reviewers are members
-  * Prerequisite: Proven track record of high-quality reviews to WG Subprojects
-  * Responsible for reviewing pull requests
-* **Approver**
-  * All approvers are reviewers
-  * Prerequisite: Proven track record of high-quality contributions and reviews to WG Subprojects
-  * Responsible for approving and merging pull requests
-  * Responsible for vetting and accepting new projects into the Working Group
-* **Lead**
-  * TSC member or their delegate
-  * Responsible for organizing and moderating working group meetings
-  * Responsible for posting meeting materials (minutes, recordings, etc.)
-  * Responsible for breaking ties
-
-To become a member or change role, create an issue in this repository using the appropriate issue template.
-Such applications are accepted upon unanimous agreement from Approvers, and are typically based on the applicant's history with the subprojects of the Working Group.
-The Lead role cannot be applied for, as it is an appointee of the ROS 2 TSC.
-
-### Modifying this governance document
-
-Changes to this document will be made via Pull Request.
-The PR will be merged on unanimous agreement from Approvers.

--- a/governance.md
+++ b/governance.md
@@ -1,0 +1,35 @@
+# Governance
+
+See the [WG section of the ROS 2 Project Governance page](https://docs.ros.org/en/rolling/Governance.html#working-groups-wgs).
+
+## Membership, Roles and Organization Management
+
+Working Group members may act in one or more of the following roles:
+
+* **Member**
+  * Prerequisite: Attend at least one out of the last three Working Group meetings
+  * Responsible for triaging issues
+* **Reviewer**
+  * All reviewers are members
+  * Prerequisite: Proven track record of high-quality reviews to WG Subprojects
+  * Responsible for reviewing pull requests
+* **Approver**
+  * All approvers are reviewers
+  * Prerequisite: Proven track record of high-quality contributions and reviews to WG Subprojects
+  * Responsible for approving and merging pull requests
+  * Responsible for vetting and accepting new projects into the Working Group
+* **Lead**
+  * TSC member or their delegate
+  * Responsible for organizing and moderating working group meetings
+  * Responsible for posting meeting materials (minutes, recordings, etc.)
+  * Responsible for breaking ties
+
+To become a member or change role, create an issue in this repository using the appropriate issue template.
+Such applications are accepted upon unanimous agreement from Approvers, and are typically based on the applicant's history with the subprojects of the Working Group.
+The Lead role cannot be applied for, as it is an appointee of the ROS 2 TSC.
+
+## Modifying this governance document
+
+Changes to this document will be made via Pull Request.
+The PR will be merged on unanimous agreement from Approvers.
+


### PR DESCRIPTION
This PR moves the governance sections to the CONTRIBUTING.md and governance.md documents. The goal is to clean-up the main document so only the most relevant information for new users is shown. 